### PR TITLE
Extend the parser to compile caret and dollar

### DIFF
--- a/src/basic-sets.ts
+++ b/src/basic-sets.ts
@@ -32,3 +32,6 @@ export function nothing(): boolean {
 export function union(first: Predicate, next: Predicate): Predicate {
 	return codepoint => first(codepoint) || next(codepoint);
 }
+
+export const INPUT_START_SENTINAL = -1;
+export const INPUT_END_SENTINAL = -2;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { compileVM } from 'whynot';
+import { INPUT_END_SENTINAL, INPUT_START_SENTINAL } from './basic-sets';
 import { compileRegExp } from './compiler';
 import { generateParser } from './parser';
 
@@ -19,16 +20,18 @@ export type Options = {
  * @return a matcher function, or null if the pattern uses unsupported features
  */
 export function compile(pattern: string, options: Options = { language: 'xsd' }): MatchFn {
-	let ast = generateParser(options)(pattern);
+	const ast = generateParser(options)(pattern);
 
 	const vm = compileVM<number>(assembler => {
-		compileRegExp(assembler, ast);
+		compileRegExp(assembler, ast, options.language === 'xpath');
 		assembler.accept();
 	});
 
 	return function match(str: string): boolean {
 		const codepoints =
-			options.language === 'xpath' ? [-1, ...toCodePoints(str), -2] : toCodePoints(str);
+			options.language === 'xpath'
+				? [INPUT_START_SENTINAL, ...toCodePoints(str), INPUT_END_SENTINAL]
+				: toCodePoints(str);
 		return vm.execute(codepoints).success;
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { compileVM } from 'whynot';
 import { compileRegExp } from './compiler';
-import { parse } from './parser';
+import { generateParser } from './parser';
 
 function toCodePoints(str: string): number[] {
 	return [...str].map(c => c.codePointAt(0)!);
@@ -8,13 +8,18 @@ function toCodePoints(str: string): number[] {
 
 export type MatchFn = (str: string) => boolean;
 
+export type Options = {
+	language: 'xsd' | 'xpath';
+};
+
 /**
  * @param pattern Pattern to compile
+ * @param options Additional options for the compiler
  *
  * @return a matcher function, or null if the pattern uses unsupported features
  */
-export function compile(pattern: string): MatchFn {
-	const ast = parse(pattern);
+export function compile(pattern: string, options: Options = { language: 'xsd' }): MatchFn {
+	let ast = generateParser(options)(pattern);
 
 	const vm = compileVM<number>(assembler => {
 		compileRegExp(assembler, ast);
@@ -22,6 +27,8 @@ export function compile(pattern: string): MatchFn {
 	});
 
 	return function match(str: string): boolean {
-		return vm.execute(toCodePoints(str)).success;
+		const codepoints =
+			options.language === 'xpath' ? [-1, ...toCodePoints(str), -2] : toCodePoints(str);
+		return vm.execute(codepoints).success;
 	};
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -44,6 +44,7 @@ const BRACE_CLOSE = token('}');
 const BRACKET_OPEN = token('[');
 const BRACKET_CLOSE = token(']');
 const CARET = token('^');
+const DOLLAR = token('$');
 const COMMA = token(',');
 const HYPHEN = token('-');
 const PARENTHESIS_OPEN = token('(');
@@ -54,321 +55,402 @@ const PLUS = token('+');
 const QUESTION_MARK = token('?');
 const SUBTRACT_MARKER = token('-[');
 
-function asSetOfCodepoints(chars: string): Set<Codepoint> {
-	return new Set(chars.split('').map(c => asCodepoint(c)));
-}
-
-function codepoint(input: string, offset: number): ParseResult<Codepoint> {
-	const codepoint = input.codePointAt(offset);
-	if (codepoint === undefined) {
-		return error(offset, ['any character']);
+export function generateParser(options: { language: string }): (input: string) => RegExp {
+	function asSetOfCodepoints(chars: string): Set<Codepoint> {
+		return new Set(chars.split('').map(c => asCodepoint(c)));
 	}
-	return okWithValue(offset + String.fromCodePoint(codepoint).length, codepoint);
-}
 
-// Single Character Escape
+	function codepoint(input: string, offset: number): ParseResult<Codepoint> {
+		const codepoint = input.codePointAt(offset);
+		if (codepoint === undefined) {
+			return error(offset, ['any character']);
+		}
+		return okWithValue(offset + String.fromCodePoint(codepoint).length, codepoint);
+	}
 
-const SingleCharEsc: Parser<Codepoint> = preceded(
-	BACKSLASH,
-	or([
-		map(token('n'), () => 0xa),
-		map(token('r'), () => 0xd),
-		map(token('t'), () => 0x9),
-		map(
-			or([
-				BACKSLASH,
-				PIPE,
-				PERIOD,
-				HYPHEN,
-				CARET,
-				QUESTION_MARK,
-				ASTERISK,
-				PLUS,
-				BRACE_OPEN,
-				BRACE_CLOSE,
-				PARENTHESIS_OPEN,
-				PARENTHESIS_CLOSE,
-				BRACKET_OPEN,
-				BRACKET_CLOSE
-			]),
-			c => asCodepoint(c)
-		)
-	])
-);
+	// Single Character Escape
 
-// Categories
+	const SingleCharEsc: Parser<Codepoint> =
+		options.language === 'xpath'
+			? preceded(
+					BACKSLASH,
+					or([
+						map(token('n'), () => 0xa),
+						map(token('r'), () => 0xd),
+						map(token('t'), () => 0x9),
+						map(
+							or([
+								BACKSLASH,
+								PIPE,
+								PERIOD,
+								HYPHEN,
+								CARET,
+								QUESTION_MARK,
+								ASTERISK,
+								PLUS,
+								BRACE_OPEN,
+								BRACE_CLOSE,
+								DOLLAR,
+								PARENTHESIS_OPEN,
+								PARENTHESIS_CLOSE,
+								BRACKET_OPEN,
+								BRACKET_CLOSE
+							]),
+							c => asCodepoint(c)
+						)
+					])
+			  )
+			: preceded(
+					BACKSLASH,
+					or([
+						map(token('n'), () => 0xa),
+						map(token('r'), () => 0xd),
+						map(token('t'), () => 0x9),
+						map(
+							or([
+								BACKSLASH,
+								PIPE,
+								PERIOD,
+								HYPHEN,
+								CARET,
+								QUESTION_MARK,
+								ASTERISK,
+								PLUS,
+								BRACE_OPEN,
+								BRACE_CLOSE,
+								PARENTHESIS_OPEN,
+								PARENTHESIS_CLOSE,
+								BRACKET_OPEN,
+								BRACKET_CLOSE
+							]),
+							c => asCodepoint(c)
+						)
+					])
+			  );
 
-function categoryIdentifier(primary: string, secondaries: string): Parser<Predicate> {
-	const secondaryChars = asSetOfCodepoints(secondaries);
-	return then(
-		token(primary),
-		optional(
-			filter(codepoint, codepoint => secondaryChars.has(codepoint), secondaries.split(''))
+	// Categories
+
+	function categoryIdentifier(primary: string, secondaries: string): Parser<Predicate> {
+		const secondaryChars = asSetOfCodepoints(secondaries);
+		return then(
+			token(primary),
+			optional(
+				filter(codepoint, codepoint => secondaryChars.has(codepoint), secondaries.split(''))
+			),
+			(p, s) => unicodeCategory(s === null ? p : p + String.fromCodePoint(s))
+		);
+	}
+
+	const Letters = categoryIdentifier('L', 'ultmo');
+	const Marks = categoryIdentifier('M', 'nce');
+	const Numbers = categoryIdentifier('N', 'dlo');
+	const Punctuation = categoryIdentifier('P', 'cdseifo');
+	const Separators = categoryIdentifier('Z', 'slp');
+	const Symbols = categoryIdentifier('S', 'mcko');
+	const Others = categoryIdentifier('C', 'cfon');
+
+	const IsCategory: Parser<Predicate> = or([
+		Letters,
+		Marks,
+		Numbers,
+		Punctuation,
+		Separators,
+		Symbols,
+		Others
+	]);
+
+	// Block Escape
+
+	const isBlockIdentifierChar: Predicate = [
+		charRangePredicate(asCodepoint('a'), asCodepoint('z')),
+		charRangePredicate(asCodepoint('A'), asCodepoint('Z')),
+		charRangePredicate(asCodepoint('0'), asCodepoint('9')),
+		singleCharPredicate(0x2d)
+	].reduce(union);
+
+	const IsBlock: Parser<Predicate> = map(
+		preceded(
+			token('Is'),
+			recognize(plus(filter(codepoint, isBlockIdentifierChar, ['block identifier'])))
 		),
-		(p, s) => unicodeCategory(s === null ? p : p + String.fromCodePoint(s))
+		unicodeBlock
 	);
-}
 
-const Letters = categoryIdentifier('L', 'ultmo');
-const Marks = categoryIdentifier('M', 'nce');
-const Numbers = categoryIdentifier('N', 'dlo');
-const Punctuation = categoryIdentifier('P', 'cdseifo');
-const Separators = categoryIdentifier('Z', 'slp');
-const Symbols = categoryIdentifier('S', 'mcko');
-const Others = categoryIdentifier('C', 'cfon');
+	// Category Escape
 
-const IsCategory: Parser<Predicate> = or([
-	Letters,
-	Marks,
-	Numbers,
-	Punctuation,
-	Separators,
-	Symbols,
-	Others
-]);
+	const charProp: Parser<Predicate> = or([IsCategory, IsBlock]);
 
-// Block Escape
+	const catEsc: Parser<Predicate> = delimited(token('\\p{'), charProp, BRACE_CLOSE, true);
 
-const isBlockIdentifierChar: Predicate = [
-	charRangePredicate(asCodepoint('a'), asCodepoint('z')),
-	charRangePredicate(asCodepoint('A'), asCodepoint('Z')),
-	charRangePredicate(asCodepoint('0'), asCodepoint('9')),
-	singleCharPredicate(0x2d)
-].reduce(union);
-
-const IsBlock: Parser<Predicate> = map(
-	preceded(
-		token('Is'),
-		recognize(plus(filter(codepoint, isBlockIdentifierChar, ['block identifier'])))
-	),
-	unicodeBlock
-);
-
-// Category Escape
-
-const charProp: Parser<Predicate> = or([IsCategory, IsBlock]);
-
-const catEsc: Parser<Predicate> = delimited(token('\\p{'), charProp, BRACE_CLOSE, true);
-
-const complEsc: Parser<Predicate> = map(
-	delimited(token('\\P{'), charProp, BRACE_CLOSE, true),
-	complement
-);
-
-// Multi-Character Escape
-
-const MultiCharEsc: Parser<Predicate> = preceded(
-	BACKSLASH,
-	map(
-		or('sSiIcCdDwW'.split('').map(c => token(c))) as Parser<keyof typeof multiChar>,
-		c => multiChar[c]
-	)
-);
-
-const WildcardEsc: Parser<Predicate> = map(PERIOD, () => wildcard);
-
-// Character Class Escape
-
-const charClassEsc: Parser<Predicate> = or([MultiCharEsc, catEsc, complEsc]);
-
-// Single Unescaped Character
-
-const notSingleCharNoEsc = asSetOfCodepoints('\\[]');
-
-const SingleCharNoEsc: Parser<Codepoint> = filter(
-	codepoint,
-	codepoint => !notSingleCharNoEsc.has(codepoint),
-	['unescaped character']
-);
-
-const singleChar: Parser<Codepoint> = or([SingleCharEsc, SingleCharNoEsc]);
-
-// Character Range
-
-const singleCharHyphenAsNull: Parser<Codepoint | null> = or([map(HYPHEN, () => null), singleChar]);
-
-const charRange: Parser<Predicate> = then(
-	singleCharHyphenAsNull,
-	preceded(HYPHEN, singleCharHyphenAsNull),
-	charRangePredicate
-);
-
-// Character Group Part
-
-function cons<T>(first: T, rest: T[] | null) {
-	return [first].concat(rest || []);
-}
-
-const assertEndOfCharGroup: Parser<null> = map(
-	peek(or([BRACKET_CLOSE, SUBTRACT_MARKER])),
-	() => null
-);
-
-const hyphenCodepoint = asCodepoint('-');
-const singleCharHyphenWithHyphenRules: Parser<Codepoint> = map(
-	followed(followed(HYPHEN, not(BRACKET_OPEN, ['not ['])), assertEndOfCharGroup),
-	() => hyphenCodepoint
-);
-
-const singleCharWithHyphenRules: Parser<Codepoint> = or([
-	singleCharHyphenWithHyphenRules,
-	preceded(not(HYPHEN, ['not -']), singleChar)
-]);
-
-const charGroupPartsWithHyphenRules: Parser<Predicate[]> = or([
-	then(
-		map(singleCharWithHyphenRules, singleCharPredicate),
-		or([charGroupPartsWithHyphenRulesIndirect, assertEndOfCharGroup]),
-		cons
-	),
-	then(or([charRange, charClassEsc]), or([charGroupPartsIndirect, assertEndOfCharGroup]), cons)
-]);
-
-function charGroupPartsWithHyphenRulesIndirect(
-	input: string,
-	offset: number
-): ParseResult<Predicate[]> {
-	return charGroupPartsWithHyphenRules(input, offset);
-}
-
-const charGroupParts: Parser<Predicate[]> = or([
-	then(
-		map(singleChar, singleCharPredicate),
-		or([charGroupPartsWithHyphenRules, assertEndOfCharGroup]),
-		cons
-	),
-	then(or([charRange, charClassEsc]), or([charGroupPartsIndirect, assertEndOfCharGroup]), cons)
-]);
-
-function charGroupPartsIndirect(input: string, offset: number): ParseResult<Predicate[]> {
-	return charGroupParts(input, offset);
-}
-
-// Positive Character Group
-
-const posCharGroup: Parser<Predicate> = map(charGroupParts, parts => parts.reduce(union));
-
-// Negative Character Group
-
-const negCharGroup: Parser<Predicate> = map(preceded(CARET, posCharGroup), complement);
-
-// Character Group
-
-const charGroup: Parser<Predicate> = then(
-	or([preceded(not(CARET, ['not ^']), posCharGroup), negCharGroup]),
-	optional(preceded(HYPHEN, charClassExprIndirect)),
-	difference
-);
-
-// Character Class Expression
-
-const charClassExpr: Parser<Predicate> = delimited(BRACKET_OPEN, charGroup, BRACKET_CLOSE, true);
-
-function charClassExprIndirect(input: string, offset: number): ParseResult<Predicate> {
-	return charClassExpr(input, offset);
-}
-
-// Character Class
-
-const charClass: Parser<Predicate> = or([
-	map(SingleCharEsc, singleCharPredicate),
-	charClassEsc,
-	charClassExpr,
-	WildcardEsc
-]);
-
-// Normal Character
-
-const metachars = asSetOfCodepoints('.\\?*+{}()|[]');
-const NormalChar: Parser<Codepoint> = filter(codepoint, codepoint => !metachars.has(codepoint), [
-	'NormalChar'
-]);
-
-// Atom
-
-const atom: Parser<Atom> = or<Atom>([
-	map(NormalChar, codepoint => ({ kind: 'predicate', value: singleCharPredicate(codepoint) })),
-	map(charClass, predicate => ({ kind: 'predicate', value: predicate })),
-	map(delimited(PARENTHESIS_OPEN, regexpIndirect, PARENTHESIS_CLOSE, true), regexp => ({
-		kind: 'regexp',
-		value: regexp
-	}))
-]);
-
-// Quantifier
-
-const zeroCodepoint = asCodepoint('0');
-const isDigit = charRangePredicate(zeroCodepoint, asCodepoint('9'));
-const QuantExact: Parser<number> = map(
-	plus(map(filter(codepoint, isDigit, ['digit']), codepoint => codepoint - zeroCodepoint)),
-	digits => digits.reduce((num, digit) => num * 10 + digit)
-);
-
-const quantRange: Parser<Quantifier> = then(QuantExact, preceded(COMMA, QuantExact), (min, max) => {
-	if (max < min) {
-		throw new Error('quantifier range is in the wrong order');
-	}
-	return { min, max };
-});
-
-const quantMin: Parser<Quantifier> = then(QuantExact, COMMA, min => ({ min, max: null }));
-
-const quantity: Parser<Quantifier> = or([
-	quantRange,
-	quantMin,
-	map(QuantExact, q => ({ min: q, max: q }))
-]);
-
-const quantifier: Parser<Quantifier> = or<Quantifier>([
-	map(QUESTION_MARK, () => ({ min: 0, max: 1 })),
-	map(ASTERISK, () => ({ min: 0, max: null })),
-	map(PLUS, () => ({ min: 1, max: null })),
-	delimited(BRACE_OPEN, quantity, BRACE_CLOSE, true)
-]);
-
-// Piece
-
-const piece: Parser<Piece> = then(
-	atom,
-	map(optional(quantifier), q => (q === null ? { min: 1, max: 1 } : q)),
-	(a, q) => [a, q]
-);
-
-// Branch
-
-const branch: Parser<Branch> = star(piece);
-
-// Regular Expression - with wrapper because of recursion
-
-const regexp: Parser<RegExp> = then(branch, star(preceded(PIPE, cut(branch))), (b, bs) =>
-	[b].concat(bs)
-);
-
-function regexpIndirect(input: string, offset: number): ParseResult<RegExp> {
-	return regexp(input, offset);
-}
-
-function throwParseError(input: string, offset: number, expected: string[]): never {
-	const quoted = expected.map(str => `"${str}"`);
-	throw new Error(
-		`Error parsing pattern "${input}" at offset ${offset}: expected ${
-			quoted.length > 1 ? 'one of ' + quoted.join(', ') : quoted[0]
-		} but found "${input.slice(offset, offset + 1)}"`
+	const complEsc: Parser<Predicate> = map(
+		delimited(token('\\P{'), charProp, BRACE_CLOSE, true),
+		complement
 	);
-}
 
-const completeRegexp: Parser<RegExp> = complete(regexp);
+	// Multi-Character Escape
 
-export function parse(input: string): RegExp {
-	let res: ParseResult<RegExp>;
-	try {
-		res = completeRegexp(input, 0);
-	} catch (error) {
-		// Generic error
-		throw new Error(`Error parsing pattern "${input}": ${error.message}`);
+	const MultiCharEsc: Parser<Predicate> = preceded(
+		BACKSLASH,
+		map(
+			or('sSiIcCdDwW'.split('').map(c => token(c))) as Parser<keyof typeof multiChar>,
+			c => multiChar[c]
+		)
+	);
+
+	const WildcardEsc: Parser<Predicate> = map(PERIOD, () => wildcard);
+
+	// Character Class Escape
+
+	const charClassEsc: Parser<Predicate> = or([MultiCharEsc, catEsc, complEsc]);
+
+	// Single Unescaped Character
+
+	const notSingleCharNoEsc = asSetOfCodepoints('\\[]');
+
+	const SingleCharNoEsc: Parser<Codepoint> = filter(
+		codepoint,
+		codepoint => !notSingleCharNoEsc.has(codepoint),
+		['unescaped character']
+	);
+
+	const singleChar: Parser<Codepoint> = or([SingleCharEsc, SingleCharNoEsc]);
+
+	// Character Range
+
+	const singleCharHyphenAsNull: Parser<Codepoint | null> = or([
+		map(HYPHEN, () => null),
+		singleChar
+	]);
+
+	const charRange: Parser<Predicate> = then(
+		singleCharHyphenAsNull,
+		preceded(HYPHEN, singleCharHyphenAsNull),
+		charRangePredicate
+	);
+
+	// Character Group Part
+
+	function cons<T>(first: T, rest: T[] | null) {
+		return [first].concat(rest || []);
 	}
-	if (!res.success) {
-		return throwParseError(input, res.offset, res.expected);
+
+	const assertEndOfCharGroup: Parser<null> = map(
+		peek(or([BRACKET_CLOSE, SUBTRACT_MARKER])),
+		() => null
+	);
+
+	const hyphenCodepoint = asCodepoint('-');
+	const singleCharHyphenWithHyphenRules: Parser<Codepoint> = map(
+		followed(followed(HYPHEN, not(BRACKET_OPEN, ['not ['])), assertEndOfCharGroup),
+		() => hyphenCodepoint
+	);
+
+	const singleCharWithHyphenRules: Parser<Codepoint> = or([
+		singleCharHyphenWithHyphenRules,
+		preceded(not(HYPHEN, ['not -']), singleChar)
+	]);
+
+	const charGroupPartsWithHyphenRules: Parser<Predicate[]> = or([
+		then(
+			map(singleCharWithHyphenRules, singleCharPredicate),
+			or([charGroupPartsWithHyphenRulesIndirect, assertEndOfCharGroup]),
+			cons
+		),
+		then(
+			or([charRange, charClassEsc]),
+			or([charGroupPartsIndirect, assertEndOfCharGroup]),
+			cons
+		)
+	]);
+
+	function charGroupPartsWithHyphenRulesIndirect(
+		input: string,
+		offset: number
+	): ParseResult<Predicate[]> {
+		return charGroupPartsWithHyphenRules(input, offset);
 	}
-	return res.value;
+
+	const charGroupParts: Parser<Predicate[]> = or([
+		then(
+			map(singleChar, singleCharPredicate),
+			or([charGroupPartsWithHyphenRules, assertEndOfCharGroup]),
+			cons
+		),
+		then(
+			or([charRange, charClassEsc]),
+			or([charGroupPartsIndirect, assertEndOfCharGroup]),
+			cons
+		)
+	]);
+
+	function charGroupPartsIndirect(input: string, offset: number): ParseResult<Predicate[]> {
+		return charGroupParts(input, offset);
+	}
+
+	// Positive Character Group
+
+	const posCharGroup: Parser<Predicate> = map(charGroupParts, parts => parts.reduce(union));
+
+	// Negative Character Group
+
+	const negCharGroup: Parser<Predicate> = map(preceded(CARET, posCharGroup), complement);
+
+	// Character Group
+
+	const charGroup: Parser<Predicate> = then(
+		or([preceded(not(CARET, ['not ^']), posCharGroup), negCharGroup]),
+		optional(preceded(HYPHEN, charClassExprIndirect)),
+		difference
+	);
+
+	// Character Class Expression
+
+	const charClassExpr: Parser<Predicate> = delimited(
+		BRACKET_OPEN,
+		charGroup,
+		BRACKET_CLOSE,
+		true
+	);
+
+	function charClassExprIndirect(input: string, offset: number): ParseResult<Predicate> {
+		return charClassExpr(input, offset);
+	}
+
+	// Character Class
+
+	const charClass: Parser<Predicate> =
+		options.language === 'xpath'
+			? or([
+					map(SingleCharEsc, singleCharPredicate),
+					charClassEsc,
+					charClassExpr,
+					WildcardEsc,
+					map(CARET, () => (c: Codepoint) => c === -1),
+					map(DOLLAR, () => (c: Codepoint) => c === -2)
+			  ])
+			: or([
+					map(SingleCharEsc, singleCharPredicate),
+					charClassEsc,
+					charClassExpr,
+					WildcardEsc
+			  ]);
+
+	// Normal Character
+
+	const metachars =
+		options.language === 'xpath'
+			? asSetOfCodepoints('.\\?*+{}()|^$[]')
+			: asSetOfCodepoints('.\\?*+{}()|[]');
+	const NormalChar: Parser<Codepoint> = filter(
+		codepoint,
+		codepoint => !metachars.has(codepoint),
+		['NormalChar']
+	);
+
+	// Atom
+
+	const atom: Parser<Atom> = or<Atom>([
+		map(NormalChar, codepoint => ({
+			kind: 'predicate',
+			value: singleCharPredicate(codepoint)
+		})),
+		map(charClass, predicate => ({ kind: 'predicate', value: predicate })),
+		map(delimited(PARENTHESIS_OPEN, regexpIndirect, PARENTHESIS_CLOSE, true), regexp => ({
+			kind: 'regexp',
+			value: regexp
+		}))
+	]);
+
+	// Quantifier
+
+	const zeroCodepoint = asCodepoint('0');
+	const isDigit = charRangePredicate(zeroCodepoint, asCodepoint('9'));
+	const QuantExact: Parser<number> = map(
+		plus(map(filter(codepoint, isDigit, ['digit']), codepoint => codepoint - zeroCodepoint)),
+		digits => digits.reduce((num, digit) => num * 10 + digit)
+	);
+
+	const quantRange: Parser<Quantifier> = then(
+		QuantExact,
+		preceded(COMMA, QuantExact),
+		(min, max) => {
+			if (max < min) {
+				throw new Error('quantifier range is in the wrong order');
+			}
+			return { min, max };
+		}
+	);
+
+	const quantMin: Parser<Quantifier> = then(QuantExact, COMMA, min => ({ min, max: null }));
+
+	const quantity: Parser<Quantifier> = or([
+		quantRange,
+		quantMin,
+		map(QuantExact, q => ({ min: q, max: q }))
+	]);
+
+	const quantifier: Parser<Quantifier> = or<Quantifier>([
+		map(QUESTION_MARK, () => ({ min: 0, max: 1 })),
+		map(ASTERISK, () => ({ min: 0, max: null })),
+		map(PLUS, () => ({ min: 1, max: null })),
+		delimited(BRACE_OPEN, quantity, BRACE_CLOSE, true)
+	]);
+
+	// Piece
+
+	const piece: Parser<Piece> = then(
+		atom,
+		map(optional(quantifier), q => (q === null ? { min: 1, max: 1 } : q)),
+		(a, q) => [a, q]
+	);
+
+	// Branch
+
+	const branch: Parser<Branch> = star(piece);
+
+	// Regular Expression - with wrapper because of recursion
+
+	const regexp: Parser<RegExp> = then(branch, star(preceded(PIPE, cut(branch))), (b, bs) =>
+		[b].concat(bs)
+	);
+
+	function regexpIndirect(input: string, offset: number): ParseResult<RegExp> {
+		return regexp(input, offset);
+	}
+
+	function throwParseError(input: string, offset: number, expected: string[]): never {
+		const quoted = expected.map(str => `"${str}"`);
+		throw new Error(
+			`Error parsing pattern "${input}" at offset ${offset}: expected ${
+				quoted.length > 1 ? 'one of ' + quoted.join(', ') : quoted[0]
+			} but found "${input.slice(offset, offset + 1)}"`
+		);
+	}
+
+	const completeRegexp: Parser<RegExp> = complete(regexp);
+
+	return function parse(input: string): RegExp {
+		let res: ParseResult<RegExp>;
+		try {
+			res = completeRegexp(input, 0);
+		} catch (error) {
+			// Generic error
+			throw new Error(`Error parsing pattern "${input}": ${error.message}`);
+		}
+		if (!res.success) {
+			return throwParseError(input, res.offset, res.expected);
+		}
+
+		if (options.language === 'xpath') {
+			return [
+				[
+					[{ kind: 'predicate', value: () => true }, { min: 0, max: null }],
+					[{ kind: 'regexp', value: res.value }, { min: 1, max: 1 }],
+					[{ kind: 'predicate', value: () => true }, { min: 0, max: null }]
+				]
+			];
+		}
+
+		return res.value;
+	};
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -349,18 +349,41 @@ export function generateParser(options: { language: string }): (input: string) =
 
 	// Atom
 
-	const atom: Parser<Atom> = or<Atom>([
-		map(NormalChar, codepoint => ({
-			kind: 'predicate',
-			value: singleCharPredicate(codepoint)
-		})),
-		map(charClass, predicate => ({ kind: 'predicate', value: predicate })),
-		map(delimited(PARENTHESIS_OPEN, regexpIndirect, PARENTHESIS_CLOSE, true), regexp => ({
-			kind: 'regexp',
-			value: regexp
-		}))
-	]);
-
+	const atom: Parser<Atom> =
+		options.language === 'xpath'
+			? or<Atom>([
+					map(NormalChar, codepoint => ({
+						kind: 'predicate',
+						value: singleCharPredicate(codepoint)
+					})),
+					map(charClass, predicate => ({ kind: 'predicate', value: predicate })),
+					map(
+						delimited(
+							PARENTHESIS_OPEN,
+							preceded(optional(token('?:')), regexpIndirect),
+							PARENTHESIS_CLOSE,
+							true
+						),
+						regexp => ({
+							kind: 'regexp',
+							value: regexp
+						})
+					)
+			  ])
+			: or<Atom>([
+					map(NormalChar, codepoint => ({
+						kind: 'predicate',
+						value: singleCharPredicate(codepoint)
+					})),
+					map(charClass, predicate => ({ kind: 'predicate', value: predicate })),
+					map(
+						delimited(PARENTHESIS_OPEN, regexpIndirect, PARENTHESIS_CLOSE, true),
+						regexp => ({
+							kind: 'regexp',
+							value: regexp
+						})
+					)
+			  ]);
 	// Quantifier
 
 	const zeroCodepoint = asCodepoint('0');

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -21,6 +21,7 @@ import {
 	token
 } from 'prsc';
 import { Atom, Branch, Piece, Quantifier, RegExp } from './ast';
+import { INPUT_END_SENTINAL, INPUT_START_SENTINAL } from './basic-sets';
 import {
 	asCodepoint,
 	charRange as charRangePredicate,
@@ -325,8 +326,8 @@ export function generateParser(options: { language: string }): (input: string) =
 					charClassEsc,
 					charClassExpr,
 					WildcardEsc,
-					map(CARET, () => (c: Codepoint) => c === -1),
-					map(DOLLAR, () => (c: Codepoint) => c === -2)
+					map(CARET, () => (c: Codepoint) => c === INPUT_START_SENTINAL),
+					map(DOLLAR, () => (c: Codepoint) => c === INPUT_END_SENTINAL)
 			  ])
 			: or([
 					map(SingleCharEsc, singleCharPredicate),
@@ -462,16 +463,6 @@ export function generateParser(options: { language: string }): (input: string) =
 		}
 		if (!res.success) {
 			return throwParseError(input, res.offset, res.expected);
-		}
-
-		if (options.language === 'xpath') {
-			return [
-				[
-					[{ kind: 'predicate', value: () => true }, { min: 0, max: null }],
-					[{ kind: 'regexp', value: res.value }, { min: 1, max: 1 }],
-					[{ kind: 'predicate', value: () => true }, { min: 0, max: null }]
-				]
-			];
 		}
 
 		return res.value;

--- a/test/xspattern.tests.ts
+++ b/test/xspattern.tests.ts
@@ -28,6 +28,60 @@ function check(pattern: string, examples: string[], counterExamples: string[] = 
 }
 
 describe('xspattern', () => {
+	describe('xpath', () => {
+		it('can match substrings instead of full strings', () => {
+			const match = compile('a|b', { language: 'xpath' });
+			expect('xxxaxxx').toBeMatchedBy(match, 'a|b');
+			expect('xxxbxxx').toBeMatchedBy(match, 'a|b');
+			expect('xxxyxxx').not.toBeMatchedBy(match, 'a|b');
+		});
+
+		it('can match the start of the string with "^"', () => {
+			const match = compile('^a', { language: 'xpath' });
+			expect('abc').toBeMatchedBy(match, '^a');
+			expect('a').toBeMatchedBy(match, '^a');
+			expect('b').not.toBeMatchedBy(match, '^a');
+			expect('ba').not.toBeMatchedBy(match, '^a');
+		});
+
+		it('can match the end of the string with "$"', () => {
+			const match = compile('a$', { language: 'xpath' });
+			expect('a').toBeMatchedBy(match, 'a$');
+			expect('ba').toBeMatchedBy(match, 'a$');
+			expect('b').not.toBeMatchedBy(match, 'a$');
+			expect('ab').not.toBeMatchedBy(match, 'a$');
+		});
+
+		it('can match the end of the string halfway a pattern', () => {
+			const match = compile('a($|x)', { language: 'xpath' });
+			expect('a').toBeMatchedBy(match, 'a($|x)');
+			expect('ba').toBeMatchedBy(match, 'a($|x)');
+			expect('ax').toBeMatchedBy(match, 'a($|x)');
+			expect('b').not.toBeMatchedBy(match, 'a($|x)');
+			expect('ab').not.toBeMatchedBy(match, 'a($|x)');
+		});
+
+		it('can escape "^"', () => {
+			const match = compile('a\\^', { language: 'xpath' });
+			expect('a^').toBeMatchedBy(match, 'a\\^');
+			expect('xa^x').toBeMatchedBy(match, 'a\\^');
+			expect('a').not.toBeMatchedBy(match, 'a\\^');
+			expect('ax').not.toBeMatchedBy(match, 'a\\^');
+			expect('b').not.toBeMatchedBy(match, 'a\\^');
+			expect('ab').not.toBeMatchedBy(match, 'a\\^');
+		});
+
+		it('can escape "$"', () => {
+			const match = compile('a\\$', { language: 'xpath' });
+			expect('a$').toBeMatchedBy(match, 'a\\$');
+			expect('xa$x').toBeMatchedBy(match, 'a\\$');
+			expect('a').not.toBeMatchedBy(match, 'a\\$');
+			expect('ax').not.toBeMatchedBy(match, 'a\\$');
+			expect('b').not.toBeMatchedBy(match, 'a\\$');
+			expect('ab').not.toBeMatchedBy(match, 'a\\$');
+		});
+	});
+
 	it('can compile a pattern', () => {
 		const match = compile('a|b');
 		expect('a|b').not.toBeMatchedBy(match, 'a|b');

--- a/test/xspattern.tests.ts
+++ b/test/xspattern.tests.ts
@@ -31,6 +31,8 @@ describe('xspattern', () => {
 	describe('xpath', () => {
 		it('can match substrings instead of full strings', () => {
 			const match = compile('a|b', { language: 'xpath' });
+			expect('xxxa').toBeMatchedBy(match, 'a|b');
+			expect('axxx').toBeMatchedBy(match, 'a|b');
 			expect('xxxaxxx').toBeMatchedBy(match, 'a|b');
 			expect('xxxbxxx').toBeMatchedBy(match, 'a|b');
 			expect('xxxyxxx').not.toBeMatchedBy(match, 'a|b');

--- a/test/xspattern.tests.ts
+++ b/test/xspattern.tests.ts
@@ -80,6 +80,16 @@ describe('xspattern', () => {
 			expect('b').not.toBeMatchedBy(match, 'a\\$');
 			expect('ab').not.toBeMatchedBy(match, 'a\\$');
 		});
+
+		it('allows "(?:)" for non-capturing groups', () => {
+			const match = compile('(?:a|b)?c', { language: 'xpath' });
+			expect('ac').toBeMatchedBy(match, '(?:a|b)?c');
+			expect('bc').toBeMatchedBy(match, '(?:a|b)?c');
+			expect('c').toBeMatchedBy(match, '(?:a|b)?c');
+			expect('a').not.toBeMatchedBy(match, '(?:a|b)?c');
+			expect('b').not.toBeMatchedBy(match, '(?:a|b)?c');
+			expect('x').not.toBeMatchedBy(match, '(?:a|b)?c');
+		});
 	});
 
 	it('can compile a pattern', () => {


### PR DESCRIPTION
This moves the compiler more towards also support XPath-style patterns, which differ slightly from
XSD-style patterns.

This is a bit of a dirty way to make this work, but I think the gist should be correct. To prevent writing multiple parsers, I added a geneator for it to basically curry the language into the parser. This does however cause the parser to be generated for every new compile action, which is not that elegant.

I made the caret and dollar match -1 and -2 respectively as tokens for the start and end of the input. I am open for another approach, but I think this is the least intrusive way: codepoints are always positive integers. Furthermore, I add some extra ast nodes representing `.*` to the start and end of the pattern to address the substring behaviour that is required for the fn:matches function.

Please let me know if you have any feedback. You might want to ignore whitespace in the diff though  :-P.